### PR TITLE
feat: Implement persistent volumes for worker pods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,11 @@ The bot updates automatically when running `make dev` - no manual steps needed!
 - Rate limiting is disabled in local development (dispatcher.disableRateLimit: true in values-local.yaml)
 - To manually rebuild worker image if needed: `docker build -f Dockerfile.worker -t claude-worker:latest .`
 
-## Conversation Persistence
+## Persistent Storage
 
-The Slack bot automatically persists conversations using Claude CLI's session management:
+Worker pods now use persistent volumes for data storage:
 
-1. **Automatic Session Management**: Each Slack thread gets its own Claude session ID for conversation continuity
-2. **Syncing Projects**: Use `./scripts/sync-claude-projects.sh` to copy Claude projects from host `~/.claude/projects/[dir]` to repository `.claude/projects/[relativedir]`
-3. **Container Setup**: The worker container automatically extracts `.claude/projects` data to `~/.claude/projects` with absolute paths
-4. **Auto-Resume**: The worker automatically resumes conversations using Claude CLI's built-in `--resume` functionality when continuing a thread
-5. **Git Commits**: When creating PRs, conversations are preserved in the `.claude/projects` directory for future reference
+1. **Persistent Volumes**: Each worker pod mounts a persistent volume at `/workspace` to preserve data across pod restarts
+2. **Auto-Resume**: The worker automatically resumes conversations using Claude CLI's built-in `--resume` functionality when continuing a thread in the same persistent volume
+3. **Data Persistence**: All workspace data is preserved in the persistent volume, eliminating the need for conversation file syncing
    

--- a/charts/peerbot/templates/worker-pvc.yaml
+++ b/charts/peerbot/templates/worker-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.worker.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "peerbot.fullname" . }}-worker-pvc
+  labels:
+    {{- include "peerbot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.worker.persistence.size }}
+  {{- if .Values.worker.persistence.storageClass }}
+  storageClassName: {{ .Values.worker.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/peerbot/values.yaml
+++ b/charts/peerbot/values.yaml
@@ -78,6 +78,12 @@ worker:
   # Workspace configuration
   workspace:
     sizeLimit: 10Gi
+    
+  # Persistent storage configuration
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""  # Use default storage class
 
 # Slack configuration
 slack:

--- a/packages/dispatcher/src/kubernetes/job-manager.ts
+++ b/packages/dispatcher/src/kubernetes/job-manager.ts
@@ -463,8 +463,8 @@ export class KubernetesJobManager {
             volumes: [
               {
                 name: "workspace",
-                emptyDir: {
-                  sizeLimit: "10Gi",
+                persistentVolumeClaim: {
+                  claimName: "peerbot-worker-pvc",
                 },
               },
             ],


### PR DESCRIPTION
Implements persistent volumes for worker pods and removes conversation history logic as requested in issue #23.

## Changes
- Add persistent volume claim template for workers
- Update job manager to use PVC instead of emptyDir volumes
- Remove conversation history save/restore logic from worker
- Update CLAUDE.md to reflect persistent storage usage

Closes #23

Generated with [Claude Code](https://claude.ai/code)