### PR TITLE
Implement Slack queue handlers and tighten security

### DIFF
--- a/db/migrations/001_initial_schema.sql
+++ b/db/migrations/001_initial_schema.sql
@@ -61,26 +61,42 @@ ALTER TABLE conversation_threads ENABLE ROW LEVEL SECURITY;
 
 -- Create RLS policies for user-based isolation
 -- Each user can see all bots but only their own conversation history
-CREATE POLICY user_isolation ON bots 
-FOR ALL USING (true); -- Users can see all bots
+CREATE POLICY user_isolation ON bots
+FOR ALL USING (true)
+WITH CHECK (true); -- Users can see all bots
 
-CREATE POLICY user_data_isolation ON users 
+CREATE POLICY user_data_isolation ON users
 FOR ALL USING (
+    platform_user_id = current_setting('app.current_user_id', true)
+)
+WITH CHECK (
     platform_user_id = current_setting('app.current_user_id', true)
 );
 
-CREATE POLICY user_config_isolation ON user_configs 
+CREATE POLICY user_config_isolation ON user_configs
 FOR ALL USING (
     user_id IN (
-        SELECT id FROM users 
+        SELECT id FROM users
+        WHERE platform_user_id = current_setting('app.current_user_id', true)
+    )
+)
+WITH CHECK (
+    user_id IN (
+        SELECT id FROM users
         WHERE platform_user_id = current_setting('app.current_user_id', true)
     )
 );
 
-CREATE POLICY thread_user_isolation ON conversation_threads 
+CREATE POLICY thread_user_isolation ON conversation_threads
 FOR ALL USING (
     user_id IN (
-        SELECT id FROM users 
+        SELECT id FROM users
+        WHERE platform_user_id = current_setting('app.current_user_id', true)
+    )
+)
+WITH CHECK (
+    user_id IN (
+        SELECT id FROM users
         WHERE platform_user_id = current_setting('app.current_user_id', true)
     )
 );

--- a/packages/core-runner/src/__tests__/claude-execution.test.ts
+++ b/packages/core-runner/src/__tests__/claude-execution.test.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { describe, it, expect, beforeEach, afterEach, mock, jest } from "bun:test";
+jest.mock = mock.module;
 import { spawn } from "child_process";
 import type { ChildProcess } from "child_process";
 
@@ -8,7 +9,9 @@ import type { ChildProcess } from "child_process";
 // we'll create tests based on the expected functionality from the previous analysis
 
 // Mock child_process
-jest.mock("child_process");
+jest.mock("child_process", () => ({
+  spawn: jest.fn(),
+}));
 const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
 
 describe("Claude Execution", () => {

--- a/packages/core-runner/src/__tests__/session-manager.test.ts
+++ b/packages/core-runner/src/__tests__/session-manager.test.ts
@@ -1,12 +1,15 @@
 #!/usr/bin/env bun
 
 import { describe, it, expect, beforeEach, afterEach, mock, jest } from "bun:test";
+jest.mock = mock.module;
 import { SessionManager } from "../session-manager";
 import { GcsStorage } from "../storage/gcs";
 import type { SessionContext, ConversationMessage, ProgressUpdate, SessionError } from "../types";
 
 // Mock GcsStorage
-jest.mock("../storage/gcs");
+jest.mock("../storage/gcs", () => ({
+  GcsStorage: jest.fn(),
+}));
 const MockedGcsStorage = GcsStorage as jest.MockedClass<typeof GcsStorage>;
 
 describe("SessionManager", () => {

--- a/packages/dispatcher/src/__tests__/kubernetes-job-manager.test.ts
+++ b/packages/dispatcher/src/__tests__/kubernetes-job-manager.test.ts
@@ -1,2 +1,0 @@
-// This test file has been removed as part of the transition to queue-only mode.
-// Kubernetes job management is now handled by the orchestrator package.

--- a/packages/dispatcher/src/__tests__/test-utils.ts
+++ b/packages/dispatcher/src/__tests__/test-utils.ts
@@ -4,6 +4,7 @@
  * Test utilities for dispatcher package
  */
 
+import { jest } from "bun:test";
 import type { WorkerJobRequest } from "../types";
 
 /**

--- a/packages/dispatcher/src/slack/event-handlers.ts
+++ b/packages/dispatcher/src/slack/event-handlers.ts
@@ -503,10 +503,15 @@ export class SlackEventHandlers {
     return true;
   }
 
-  // Placeholder implementations for other methods
-  private async loadSessionMapping(username: string, sessionKey: string): Promise<string | undefined> {
-    // TODO: Implement session mapping loading
-    return undefined;
+  /**
+   * Load previously stored Claude session mapping for a thread
+   * Currently uses in-memory map but can be extended to persistent storage
+   */
+  private async loadSessionMapping(
+    _username: string,
+    sessionKey: string,
+  ): Promise<string | undefined> {
+    return this.sessionMappings.get(sessionKey);
   }
 
   private async getOrCreateUserMapping(slackUserId: string, client: any): Promise<string> {
@@ -553,24 +558,120 @@ export class SlackEventHandlers {
     }, 60000);
   }
 
-  private async handleBlockAction(actionId: string, userId: string, channelId: string, messageTs: string, body: any, client: any): Promise<void> {
-    // TODO: Implement block action handling
+  private async handleBlockAction(
+    actionId: string,
+    userId: string,
+    channelId: string,
+    messageTs: string,
+    body: any,
+    client: any
+  ): Promise<void> {
     logger.info(`Handling block action: ${actionId}`);
+
+    switch (actionId) {
+      case "open_repository_override_modal":
+        await client.views.open({
+          trigger_id: body.trigger_id,
+          view: {
+            type: "modal",
+            callback_id: "repository_override_modal",
+            private_metadata: JSON.stringify({
+              channel_id: channelId,
+              thread_ts: messageTs,
+            }),
+            title: { type: "plain_text", text: "Repository" },
+            submit: { type: "plain_text", text: "Save" },
+            close: { type: "plain_text", text: "Cancel" },
+            blocks: [
+              {
+                type: "input",
+                block_id: "repo_input",
+                label: { type: "plain_text", text: "Repository URL" },
+                element: {
+                  type: "plain_text_input",
+                  action_id: "repo_url",
+                  placeholder: { type: "plain_text", text: "https://github.com/user/repo" },
+                },
+              },
+            ],
+          },
+        });
+        break;
+
+      default:
+        await client.chat.postEphemeral({
+          channel: channelId,
+          user: userId,
+          text: `Unsupported action: ${actionId}`,
+        });
+    }
   }
 
   private async updateAppHome(userId: string, client: any): Promise<void> {
-    // TODO: Implement app home update
     logger.info(`Updating app home for user: ${userId}`);
+    const homeView = {
+      type: "home",
+      blocks: [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "Welcome to Claude Code!" },
+        },
+      ],
+    };
+
+    await client.views.publish({ user_id: userId, view: homeView });
   }
 
-  private async handleRepositoryOverrideSubmission(userId: string, view: any, client: any): Promise<void> {
-    // TODO: Implement repository override submission handling
+  private async handleRepositoryOverrideSubmission(
+    userId: string,
+    view: any,
+    client: any
+  ): Promise<void> {
     logger.info(`Handling repository override submission for user: ${userId}`);
+
+    const repoUrl = view.state.values?.repo_input?.repo_url?.value?.trim();
+    const metadata = view.private_metadata ? JSON.parse(view.private_metadata) : {};
+    const channelId = metadata.channel_id;
+    const threadTs = metadata.thread_ts;
+
+    if (!repoUrl) {
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: userId,
+        text: "Please provide a repository URL.",
+      });
+      return;
+    }
+
+    const username = await this.getOrCreateUserMapping(userId, client);
+    this.repositoryCache.set(username, {
+      repository: { repositoryUrl: repoUrl },
+      timestamp: Date.now(),
+    });
+
+    if (channelId && threadTs) {
+      await client.chat.postMessage({
+        channel: channelId,
+        thread_ts: threadTs,
+        text: `✅ Repository set to ${repoUrl}`,
+      });
+    }
   }
 
   private extractViewInputs(stateValues: any): string {
-    // TODO: Implement view input extraction
-    return 'Form submitted (input extraction not implemented)';
+    const inputs: string[] = [];
+    for (const block of Object.values(stateValues || {})) {
+      for (const action of Object.values(block as any)) {
+        const value =
+          (action as any).value ||
+          (action as any).selected_option?.value ||
+          "";
+        if (value) {
+          inputs.push(value);
+        }
+      }
+    }
+    return inputs.join("\n");
   }
 
   /**

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -27,8 +27,8 @@ function loadConfig(): OrchestratorConfig {
       ssl: process.env.DATABASE_SSL === "true",
     },
     pgboss: {
-      connectionString: process.env.PGBOSS_CONNECTION_STRING || 
-        `postgres://${process.env.DATABASE_USER}:${process.env.DATABASE_PASSWORD}@${process.env.DATABASE_HOST}:${process.env.DATABASE_PORT}/${process.env.DATABASE_NAME}`,
+      connectionString: process.env.PGBOSS_CONNECTION_STRING ||
+        `postgres://${encodeURIComponent(process.env.DATABASE_USER || "")}:${encodeURIComponent(process.env.DATABASE_PASSWORD || "" )}@${process.env.DATABASE_HOST}:${process.env.DATABASE_PORT}/${process.env.DATABASE_NAME}`,
       retryLimit: parseInt(process.env.PGBOSS_RETRY_LIMIT || "3"),
       retryDelay: parseInt(process.env.PGBOSS_RETRY_DELAY || "30"),
       expireInHours: parseInt(process.env.PGBOSS_EXPIRE_HOURS || "24"),

--- a/packages/worker/src/__tests__/test-utils.ts
+++ b/packages/worker/src/__tests__/test-utils.ts
@@ -4,6 +4,8 @@
  * Test utilities for worker package
  */
 
+import { jest } from "bun:test";
+
 /**
  * Mock environment variables for testing
  */

--- a/packages/worker/src/__tests__/worker-main.test.ts
+++ b/packages/worker/src/__tests__/worker-main.test.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { describe, it, expect, beforeEach, afterEach, mock, jest } from "bun:test";
+jest.mock = mock.module;
 
 // Mock core-runner since worker depends on it
 jest.mock("../../core-runner", () => ({

--- a/packages/worker/src/__tests__/workspace-setup.test.ts
+++ b/packages/worker/src/__tests__/workspace-setup.test.ts
@@ -1,12 +1,15 @@
 #!/usr/bin/env bun
 
 import { describe, it, expect, beforeEach, afterEach, mock, jest } from "bun:test";
+jest.mock = mock.module;
 import { spawn } from "child_process";
 import { promises as fs } from "fs";
 import { join } from "path";
 
 // Mock dependencies
-jest.mock("child_process");
+jest.mock("child_process", () => ({
+  spawn: jest.fn(),
+}));
 jest.mock("fs", () => ({
   promises: {
     mkdir: jest.fn(),

--- a/packages/worker/src/queue-persistent-worker.ts
+++ b/packages/worker/src/queue-persistent-worker.ts
@@ -49,9 +49,9 @@ export class QueuePersistentClaudeWorker {
     const host = process.env.DATABASE_HOST || "localhost";
     const port = process.env.DATABASE_PORT || "5432";
     const database = process.env.DATABASE_NAME || "peerbot";
-    const username = process.env.DATABASE_USER || "postgres";
-    const password = process.env.DATABASE_PASSWORD || "";
-    
+    const username = encodeURIComponent(process.env.DATABASE_USER || "postgres");
+    const password = encodeURIComponent(process.env.DATABASE_PASSWORD || "");
+
     return `postgres://${username}:${password}@${host}:${port}/${database}`;
   }
 

--- a/packages/worker/src/queue/queue-consumer.ts
+++ b/packages/worker/src/queue/queue-consumer.ts
@@ -49,9 +49,6 @@ export class WorkerQueueConsumer {
     try {
       await this.pgBoss.start();
       
-      // Set bot context for RLS
-      await this.setBotContext(this.botId);
-      
       // Generate queue name for this specific thread
       const queueName = this.getThreadQueueName();
       
@@ -107,9 +104,12 @@ export class WorkerQueueConsumer {
 
     this.isProcessing = true;
     const data = job.data;
-    
+
     try {
       logger.info(`Processing thread message job ${job.id} for bot ${data.botId}, thread ${data.threadId}`);
+
+      // Set user context for any database operations
+      process.env.CURRENT_USER_ID = data.userId;
 
       // Convert queue payload to WorkerConfig format
       const workerConfig = this.payloadToWorkerConfig(data);
@@ -181,20 +181,6 @@ export class WorkerQueueConsumer {
         githubToken: process.env.GITHUB_TOKEN!,
       },
     };
-  }
-
-  /**
-   * Set bot context for RLS policies
-   */
-  private async setBotContext(botId: string): Promise<void> {
-    try {
-      // Set bot context in environment for RLS
-      process.env.CURRENT_BOT_ID = botId;
-      logger.debug(`Set bot context for worker: ${botId}`);
-    } catch (error) {
-      logger.error(`Failed to set bot context for ${botId}:`, error);
-      throw error;
-    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- implement missing Slack dispatcher handlers for block actions, app home updates, repository overrides, and view parsing
- remove placeholder queue files and update tests to use Bun's mocking utilities
- harden RLS policies and escape database credentials for queue-based workers

## Testing
- `bun test` *(fails: Cannot find module '@actions/core', missing timer/mocking APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c82b9b4483258b60316ea3f63f5c